### PR TITLE
Delete check _volumeFileNames.Count

### DIFF
--- a/SevenZip/SevenZipExtractor.cs
+++ b/SevenZip/SevenZipExtractor.cs
@@ -410,8 +410,7 @@ namespace SevenZip
             }
             else
             {
-                if (!_fileName.EndsWith(".001", StringComparison.OrdinalIgnoreCase)
-                    || (_volumeFileNames.Count == 1))
+                if (!_fileName.EndsWith(".001", StringComparison.OrdinalIgnoreCase))
                 {
                     _archiveStream = new InStreamWrapper(
                         new ArchiveEmulationStreamProxy(new FileStream(


### PR DESCRIPTION
_volomeFileNames initialized after calling GetArhiveStream, so when you try to open a multivolume archive arises Null Reference
