### PR TITLE
NullReferenceException in CommonDispose

### DIFF
--- a/SevenZip/SevenZipExtractor.cs
+++ b/SevenZip/SevenZipExtractor.cs
@@ -760,9 +760,14 @@ namespace SevenZip
             _archiveFileData = null;
             _archiveProperties = null;
             _archiveFileInfoCollection = null;
-            _inStream.Dispose();
-            _inStream = null;
-            if (_openCallback != null)
+            
+	    if (_inStream != null)
+	    {
+                _inStream.Dispose();
+                _inStream = null;
+	    }
+            
+	    if (_openCallback != null)
             {
                 try
                 {


### PR DESCRIPTION
In the dispose was a NullReferenceException by using the extractor in an using block. By using the ModifyArchive method was the same problem.